### PR TITLE
update README for fixing tup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ $ tup init
 $ tup upd
 ```
 
+On UNIX or Linux systems, you might need to remove the `.lua` source
+files first to get `tup` to build properly:
+
+```bash
+$ find . -name "*.lua" -exec rm {} \;
+```
+
 # Contact
 
 Author: Leaf Corcoran (leafo) ([@moonscript](http://twitter.com/moonscript))  


### PR DESCRIPTION
Hi @leafo -

I'm new to lapis, but am really enjoying your framework. It's really slick. :+1:

I decided to try out this console for it, but ran into a small issue after cloning the repo. Upon running tup upd, I get the following error:

``` bash
[ tup ] [0.001s] Scanning filesystem...
[ tup ] [0.003s] Reading in new environment variables...
[ tup ] [0.004s] Parsing Tupfiles...
 1) [0.004s] .
 2) [0.001s] lapis                                                                                                            
* 3) [0.002s] lapis/console                                                                                                   
tup error: Attempting to insert 'init.lua' as a generated node when it already exists as a different type (normal file). You ca
n do one of two things to fix this:
  1) If this file is really supposed to be created from the command, delete the file from the filesystem and try again.
  2) Change your rule in the Tupfile so you aren't trying to overwrite the file.
tup error: Error parsing ../../Tuprules.tup line 4
  Line was: ': foreach *.moon |> moonc %f |> %B.lua'
tup error: Failed to parse included file '../../Tuprules.tup'
tup error: Error parsing Tupfile line 1
  Line was: 'include_rules'
 [ ETA~=<1s  ]  27%
 *** tup: 1 job failed.
```

**The fix was easy and I've updated the README to better reflect the solution.**

I thought that another consideration would be to remove these .lua files from the project altogether since they're automatically built. However, that might have some downsides with it as well.

I'll be happy to issue a PR for that instead if you'd rather not update the README.

Also, is there any reason this project is not available via luarocks?

Thanks again,
Chip
