### PR TITLE
Added moonscript dependency

### DIFF
--- a/lapis-console-dev-1.rockspec
+++ b/lapis-console-dev-1.rockspec
@@ -13,7 +13,8 @@ description = {
 
 dependencies = {
   "lua == 5.1",
-  "lapis"
+  "lapis",
+  "moonscript"
 }
 
 build = {


### PR DESCRIPTION
Does not work until you install moonscript, so I took a stab at adding the moonscript dependency.

```
2016/03/28 12:56:46 [error] 8090#0: *11 lua coroutine: runtime error: /usr/local/share/lua/5.1/lapis/console/init.lua:171: module 'moonscript.base' not found:
    no field package.preload['moonscript.base']could not load `etlua` file
    no file '/usr/local/openresty/lualib/moonscript/base.lua'
    no file '/usr/local/openresty/lualib/moonscript/base/init.lua'
    no file '/usr/local/share/lua/5.1/moonscript/base.lua'
    no file '/usr/local/share/lua/5.1/moonscript/base/init.lua'
    no file '/home/vadi/.luarocks/share/lua/5.1/moonscript/base.lua'
    no file '/home/vadi/.luarocks/share/lua/5.1/moonscript/base/init.lua'
    no file '/usr/local/share/lua/5.1//moonscript/base.lua'
    no file '/usr/local/share/lua/5.1//moonscript/base/init.lua'
    no file './moonscript/base.lua'
    no file '/usr/local/share/lua/5.1/moonscript/base.lua'
    no file '/usr/local/share/lua/5.1/moonscript/base/init.lua'
    no file '/usr/local/lib/lua/5.1/moonscript/base.lua'
    no file '/usr/local/lib/lua/5.1/moonscript/base/init.lua'
    no file '/usr/share/lua/5.1/moonscript/base.lua'
    no file '/usr/share/lua/5.1/moonscript/base/init.lua'
    no file '/usr/local/openresty/lualib/moonscript/base.so'
    no file '/usr/local/lib/lua/5.1/moonscript/base.so'
    no file '/home/vadi/.luarocks/lib/lua/5.1/moonscript/base.so'
    no file './moonscript/base.so'
    no file '/usr/local/lib/lua/5.1/moonscript/base.so'
    no file '/usr/lib/x86_64-linux-gnu/lua/5.1/moonscript/base.so'
    no file '/usr/lib/lua/5.1/moonscript/base.so'
    no file '/usr/local/lib/lua/5.1/loadall.so'
    no file '/usr/local/openresty/lualib/moonscript.so'
    no file '/usr/local/lib/lua/5.1/moonscript.so'
    no file '/home/vadi/.luarocks/lib/lua/5.1/moonscript.so'
    no file './moonscript.so'
    no file '/usr/local/lib/lua/5.1/moonscript.so'
    no file '/usr/lib/x86_64-linux-gnu/lua/5.1/moonscript.so'
    no file '/usr/lib/lua/5.1/moonscript.so'
    no file '/usr/local/lib/lua/5.1/loadall.so'
stack traceback:
coroutine 0:
    [C]: in function 'require'
    /usr/local/share/lua/5.1/lapis/console/init.lua:171: in function </usr/local/share/lua/5.1/lapis/console/init.lua:158>
coroutine 1:
    [C]: in function 'resume'
    /usr/local/share/lua/5.1/lapis/application.lua:665: in function 'handler'
    /usr/local/share/lua/5.1/lapis/application.lua:402: in function 'resolve'
    /usr/local/share/lua/5.1/lapis/application.lua:411: in function </usr/local/share/lua/5.1/lapis/application.lua:409>
    [C]: in function 'xpcall'
    /usr/local/share/lua/5.1/lapis/application.lua:409: in function 'dispatch'
    /usr/local/share/lua/5.1/lapis/nginx.lua:205: in function 'serve'
    content_by_lua(nginx.conf.compiled:22):2: in function <content_by_lua(nginx.conf.compiled:22):1>, client: 127.0.0.1, server: , request: "POST /console?lang=moonscript HTTP/1.1", host: "localhost:8080", referrer: "http://localhost:8080/console"
```
